### PR TITLE
fix Bug 59556 - support "jdk" package for Java 7+

### DIFF
--- a/src/main/org/apache/tools/ant/util/JavaEnvUtils.java
+++ b/src/main/org/apache/tools/ant/util/JavaEnvUtils.java
@@ -430,6 +430,8 @@ public final class JavaEnvUtils {
             case VERSION_1_9:
             case VERSION_1_8:
             case VERSION_1_7:
+                jrePackages.addElement("jdk");
+                // fall through
             case VERSION_1_6:
             case VERSION_1_5:
                 //In Java1.5, the apache stuff moved.
@@ -483,6 +485,8 @@ public final class JavaEnvUtils {
             case VERSION_1_9:
             case VERSION_1_8:
             case VERSION_1_7:
+                tests.addElement("jdk.net.Sockets");
+                // fall through
             case VERSION_1_6:
             case VERSION_1_5:
                 tests.addElement(


### PR DESCRIPTION
Patch based on Chris Hegarty (Oracle) work.
"jdk" package has been introduced in JDK7 but is not known from Ant, and causes NoClassDefFoundError with JDK9 b116+.
"jdk.net.Sockets" has been chosen as test class because it is available in JDK7, JDK8 and JDK9.
